### PR TITLE
[Logan] Remove HTML comments before diffing

### DIFF
--- a/js/htmldiff.js
+++ b/js/htmldiff.js
@@ -41,11 +41,19 @@
   }
 
   function is_tag(token){
-    return /^\s*<[^>]+>\s*$/.test(token);
+    return /^\s*<[^!>][^>]*>\s*$/.test(token);
   }
 
   function isnt_tag(token){
     return !is_tag(token);
+  }
+
+  function is_start_of_html_comment(word) {
+    return /^<!--/.test(word);
+  }
+
+  function is_end_of_html_comment(word) {
+    return /--\>$/.test(word);
   }
 
   /*
@@ -162,6 +170,9 @@
             mode = 'atomic_tag';
             current_atomic_tag = atomic_tag;
             current_word += char;
+          } else if (is_start_of_html_comment(current_word)) {
+            mode = 'html_comment';
+            current_word += char;
           } else if (is_end_of_tag(char)){
             current_word += '>';
             words.push(create_token(current_word));
@@ -184,6 +195,13 @@
             mode = 'char';
           } else {
             current_word += char;
+          }
+          break;
+        case 'html_comment':
+          current_word += char;
+          if (is_end_of_html_comment(current_word)){
+            current_word = '';
+            mode = 'char';
           }
           break;
         case 'char':

--- a/test/html_to_tokens.spec.js
+++ b/test/html_to_tokens.spec.js
@@ -38,7 +38,6 @@ describe('html_to_tokens', function(){
 
     it('should remove any html comments', function() {
       res = cut('<p> this is <!-- a comment! --> </p>');
-      console.log(res);
       expect(res.length).to.equal(8);
     });
   }); // describe('when called with html')

--- a/test/html_to_tokens.spec.js
+++ b/test/html_to_tokens.spec.js
@@ -35,6 +35,12 @@ describe('html_to_tokens', function(){
     it('should return 11', function(){
       expect(res.length).to.equal(11);
     });
+
+    it('should remove any html comments', function() {
+      res = cut('<p> this is <!-- a comment! --> </p>');
+      console.log(res);
+      expect(res.length).to.equal(8);
+    });
   }); // describe('when called with html')
 
   it('should identify contiguous whitespace as a single token', function(){


### PR DESCRIPTION
This avoids us accidentally wrapping a \<ins\>...\</ins\> or \<del\>...\</del\> around the start or end of an html comment losing the opening or closing element, and screwing up the dom.