### PR TITLE
Identify groups of edits and whole tags in diff output

### DIFF
--- a/js/htmldiff.js
+++ b/js/htmldiff.js
@@ -40,6 +40,13 @@
         return /^\s+$/.test(char);
     }
 
+    /**
+     * Determines if the given token is a tag.
+     *
+     * @param {string} token The token in question.
+     *
+     * @return {boolean|string} False if the token is not a tag, or the tag name otherwise.
+     */
     function isTag(token){
         var match = token.match(/^\s*<([^!>][^>]*)>\s*$/);
         return !!match && match[1].trim().split(' ')[0];
@@ -822,6 +829,8 @@
      *      - {number} endInAfter The end of the range in the list of after tokens.
      * @param {Array.<string>} beforeTokens The before list of tokens.
      * @param {Array.<string>} afterTokens The after list of tokens.
+     * @param {number} opIndex The index into the list of operations that identifies the change to
+     *      be rendered. This is used to mark wrapped HTML as part of the same operation.
      * @param {string} dataPrefix (Optional) The prefix to use in data attributes.
      * @param {string} className (Optional) The class name to include in the wrapper tag.
      *

--- a/js/htmldiff.js
+++ b/js/htmldiff.js
@@ -799,8 +799,11 @@
                 return segment.tokens.join('');
             }
             return '';
-        }, function(tag){
-            return tag.replace(/>\s*$/, ' data-diff-inserted="true"$&');
+        }, function(openingTag){
+            var dataAttrs = ' data-diff-node="' + tag + '"';
+            dataAttrs += ' data-operation-index="' + opIndex + '"';
+
+            return openingTag.replace(/>\s*$/, dataAttrs + '$&');
         });
     }
 

--- a/test/diff.spec.js
+++ b/test/diff.spec.js
@@ -21,7 +21,7 @@ describe('Diff', function(){
         });
 
         it('should mark the new letter', function(){
-            expect(res).to.equal('input<ins> 2</ins>');
+            expect(res).to.equal('input<ins data-operation-index="1"> 2</ins>');
         });
     });
 
@@ -42,7 +42,7 @@ describe('Diff', function(){
     describe('When a class name is specified', function(){
         it('should include the class in the wrapper tags', function(){
             expect(cut('input', 'input 2', 'diff-result')).to.equal(
-                    'input<ins class="diff-result"> 2</ins>');
+                    'input<ins data-operation-index="1" class="diff-result"> 2</ins>');
         });
     });
 });

--- a/test/diff.spec.js
+++ b/test/diff.spec.js
@@ -45,4 +45,12 @@ describe('Diff', function(){
                     'input<ins data-operation-index="1" class="diff-result"> 2</ins>');
         });
     });
+
+    describe('When a data prefix is specified', function(){
+        it('should include the data prefix in data attributes', function(){
+            expect(cut('input', 'input <b>2</b>', 'diff-result', 'prefix')).to.equal(
+                    'input<b data-diff-node="ins" data-prefix-operation-index="1">' +
+                    '<ins data-prefix-operation-index="1" class="diff-result">2</ins></b>');
+        });
+    });
 });

--- a/test/from_port_source.spec.js
+++ b/test/from_port_source.spec.js
@@ -7,21 +7,24 @@ describe('The specs from the ruby source project', function(){
 
     it('should diff text', function(){
         var diff = cut('a word is here', 'a nother word is there');
-        expect(diff).equal('a<ins> nother</ins> word is <del>here</del><ins>there</ins>');
+        expect(diff).equal('a<ins data-operation-index="1"> nother</ins> word is ' +
+                '<del data-operation-index="3">here</del><ins data-operation-index="3">' +
+                'there</ins>');
     });
 
     it('should insert a letter and a space', function(){
         var diff = cut('a c', 'a b c');
-        expect(diff).equal('a <ins>b </ins>c');
+        expect(diff).equal('a <ins data-operation-index="1">b </ins>c');
     });
 
     it('should remove a letter and a space', function(){
         var diff = cut('a b c', 'a c');
-        diff.should == 'a <del>b </del>c';
+        diff.should == 'a <del data-operation-index="1">b </del>c';
     });
 
     it('should change a letter', function(){
         var diff = cut('a b c', 'a d c');
-        expect(diff).equal('a <del>b</del><ins>d</ins> c');
+        expect(diff).equal('a <del data-operation-index="1">b</del>' +
+                '<ins data-operation-index="1">d</ins> c');
     });
 });

--- a/test/pain_games.spec.js
+++ b/test/pain_games.spec.js
@@ -11,8 +11,8 @@ describe('Pain Games', function(){
         });
 
         it('should replace the whole chunk', function(){
-            expect(res).to.equal('<del>this is what I had</del>' +
-                    '<ins>and now we have a new one</ins>');
+            expect(res).to.equal('<del data-operation-index="0">this is what I had</del>' +
+                    '<ins data-operation-index="0">and now we have a new one</ins>');
         });
     });
 });

--- a/test/render_operations.spec.js
+++ b/test/render_operations.spec.js
@@ -40,7 +40,7 @@ describe('renderOperations', function(){
         });
 
         it('should wrap in an <ins>', function(){
-            expect(res).equal('this is<ins> a test</ins>');
+            expect(res).equal('this is<ins data-operation-index="1"> a test</ins>');
         });
     });
 
@@ -53,7 +53,7 @@ describe('renderOperations', function(){
         });
 
         it('should wrap in a <del>', function(){
-            expect(res).to.equal('this is a test<del> of stuff</del>');
+            expect(res).to.equal('this is a test<del data-operation-index="1"> of stuff</del>');
         });
     });
 
@@ -65,7 +65,8 @@ describe('renderOperations', function(){
         });
 
         it('should wrap in both <ins> and <del>', function(){
-            expect(res).to.equal('this is a <del>break</del><ins>test</ins>');
+            expect(res).to.equal('this is a <del data-operation-index="1">break</del>' +
+                    '<ins data-operation-index="1">test</ins>');
         });
     });
 
@@ -77,7 +78,8 @@ describe('renderOperations', function(){
         });
 
         it('should wrap contained tags', function(){
-            expect(res).to.equal('<p>a<ins> b</ins></p><ins><p>c</p></ins>');
+            expect(res).to.equal('<p>a<ins data-operation-index="1"> b</ins></p>' +
+                    '<p data-diff-inserted="true"><ins data-operation-index="3">c</ins></p>');
         });
 
         it('should not wrap partial tags', function(){
@@ -85,7 +87,9 @@ describe('renderOperations', function(){
             var after = tokenize(['test!', '</b>', 'non-bold', '<b>', 'bold']);
             res = cut(before, after);
 
-            expect(res).to.equal('<del>test</del><ins>test!</ins></b>non-bold<b><ins>bold</ins>');
+            expect(res).to.equal('<del data-operation-index="0">test</del>' +
+                    '<ins data-operation-index="0">test!</ins></b>non-bold<b>' +
+                    '<ins data-operation-index="2">bold</ins>');
         });
 
         describe('When there is a change at the beginning, in a <p>', function(){
@@ -96,7 +100,8 @@ describe('renderOperations', function(){
             });
 
             it('should keep the change inside the <p>', function(){
-                expect(res).to.equal('<p><del>this</del><ins>I</ins> is awesome</p>');
+                expect(res).to.equal('<p><del data-operation-index="1">this</del>' +
+                        '<ins data-operation-index="1">I</ins> is awesome</p>');
             });
         });
     });
@@ -131,7 +136,8 @@ describe('renderOperations', function(){
             res = cut(before, after);
 
             expect(res).to.equal('<p style="margin: 2px;" class="after">' +
-                    '<del>this</del><ins>that</ins> is awesome</p>');
+                    '<del data-operation-index="1">this</del><ins data-operation-index="1">' +
+                    'that</ins> is awesome</p>');
         });
     });
 
@@ -142,7 +148,8 @@ describe('renderOperations', function(){
 
             res = cut(before, after);
 
-            expect(res).to.equal('<del>old</del><ins>new<br/></ins> text');
+            expect(res).to.equal('<del data-operation-index="0">old</del>' +
+                    '<ins data-operation-index="0">new<br/></ins> text');
         });
 
         it('should wrap atomic tags', function(){
@@ -152,7 +159,8 @@ describe('renderOperations', function(){
             res = cut(before, after);
 
             expect(res).to.equal(
-                    '<del>old<iframe src="source.html"></iframe></del><ins>new</ins> text');
+                    '<del data-operation-index="0">old<iframe src="source.html"></iframe></del>' +
+                    '<ins data-operation-index="0">new</ins> text');
         });
     });
 });

--- a/test/render_operations.spec.js
+++ b/test/render_operations.spec.js
@@ -76,8 +76,16 @@ describe('renderOperations', function(){
             res = cut(before, after);
         });
 
-        it('should make sure the <ins/del> tags are within the <p> tags', function(){
-            expect(res).to.equal('<p>a<ins> b</ins></p><p><ins>c</ins></p>');
+        it('should wrap contained tags', function(){
+            expect(res).to.equal('<p>a<ins> b</ins></p><ins><p>c</p></ins>');
+        });
+
+        it('should not wrap partial tags', function(){
+            var before = tokenize(['test', '</b>', 'non-bold']);
+            var after = tokenize(['test!', '</b>', 'non-bold', '<b>', 'bold']);
+            res = cut(before, after);
+
+            expect(res).to.equal('<del>test</del><ins>test!</ins></b>non-bold<b><ins>bold</ins>');
         });
 
         describe('When there is a change at the beginning, in a <p>', function(){

--- a/test/render_operations.spec.js
+++ b/test/render_operations.spec.js
@@ -71,18 +71,29 @@ describe('renderOperations', function(){
     });
 
     describe('Dealing with tags', function(){
+        var before, after;
+
         beforeEach(function(){
-            var before = tokenize(['<p>', 'a', '</p>']);
-            var after = tokenize(['<p>', 'a', ' ', 'b', '</p>', '<p>', 'c', '</p>']);
+            before = tokenize(['<p>', 'a', '</p>']);
+            after = tokenize(['<p>', 'a', ' ', 'b', '</p>', '<p>', 'c', '</p>']);
             res = cut(before, after);
         });
 
-        it('should wrap contained tags', function(){
+        it('should identify contained inserted tags', function(){
             expect(res).to.equal('<p>a<ins data-operation-index="1"> b</ins></p>' +
-                    '<p data-diff-inserted="true"><ins data-operation-index="3">c</ins></p>');
+                    '<p data-diff-node="ins" data-operation-index="3">' +
+                    '<ins data-operation-index="3">c</ins></p>');
         });
 
-        it('should not wrap partial tags', function(){
+        it('should identify contained deleted tags', function(){
+            res = cut(after, before);
+
+            expect(res).to.equal('<p>a<del data-operation-index="1"> b</del></p>' +
+                    '<p data-diff-node="del" data-operation-index="3">' +
+                    '<del data-operation-index="3">c</del></p>');
+        });
+
+        it('should not identify partial tags', function(){
             var before = tokenize(['test', '</b>', 'non-bold']);
             var after = tokenize(['test!', '</b>', 'non-bold', '<b>', 'bold']);
             res = cut(before, after);


### PR DESCRIPTION
The motivation for this is caused by things like adding some HTML in the form `this is <b>inserted</b> text` causes 3 separate `<ins>` tags to be inserted, which seems unnecessary and complicates our use of the library.