### PR TITLE
Configurable atomic tags

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2012 The Network Inc. and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # htmldiff.js
-### HTML Diffing in JavaScript
+## HTML Diffing in JavaScript
 
 [![Build Status](https://travis-ci.org/inkling/htmldiff.js.svg?branch=master)](https://travis-ci.org/inkling/htmldiff.js)
 
@@ -9,20 +9,36 @@
 This is diffing that understands HTML. Best suited for cases when you
 want to show a diff of user-generated HTML (like from a wysiwyg editor).
 
-##Usage
+## Usage (JavaScript)
 You use it like this:
 
 ```javascript
-
   diff = require('htmldiff.js');
   console.log(diff('<p>this is some text</p>', '<p>this is some more text</p>'));
 ```
+
 And you get:
 
 ```html
 <p>this is some <ins>more </ins>text</p>
 ```
-##Module
+
+## Usage (TypeScript)
+
+```typescript
+  import diff = require("htmldiff");
+  console.log(diff("<p>this is some text</p>", "<p>this is some more text</p>"));
+```
+
+`diff` is just an arbitry name for the exported default module function, you can use
+any other name you like, e. g.:
+
+```typescript
+  import diffHTML = require("htmldiff");
+  console.log(diffHTML("<p>this is some text</p>", "<p>this is some more text</p>"));
+```
+
+## Module
 
 It should be multi-module aware. ie. it should work as a node.js module
 or an AMD (RequireJS) module, or even just as a script tag.

--- a/js/htmldiff.d.ts
+++ b/js/htmldiff.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Compares two pieces of HTML content and returns the combined content with differences
+ * wrapped in <ins> and <del> tags.
+ *
+ * @param {string} before The HTML content before the changes.
+ * @param {string} after The HTML content after the changes.
+ * @param {string} className (Optional) The class attribute to include in <ins> and <del> tags.
+ * @param {string} dataPrefix (Optional) The data prefix to use for data attributes. The
+ *     operation index data attribute will be named `data-${dataPrefix-}operation-index`.
+ *
+ * @return {string} The combined HTML content with differences wrapped in <ins> and <del> tags.
+ */
+declare function diff(before: string, after: string, className?: string, dataPrefix?: string): string;
+export = diff;

--- a/js/htmldiff.d.ts
+++ b/js/htmldiff.d.ts
@@ -7,8 +7,13 @@
  * @param {string} className (Optional) The class attribute to include in <ins> and <del> tags.
  * @param {string} dataPrefix (Optional) The data prefix to use for data attributes. The
  *     operation index data attribute will be named `data-${dataPrefix-}operation-index`.
+ * @param {string} atomicTags (Optional) List of tag names. The list has to be in the form 
+ *     'tag1|tag2|tag3|...' e. g. 'head|script|style|...'. An atomic tag is one whose child 
+ *     nodes should not be compared - the entire tag should be treated as one token. This is 
+ *     useful for tags where it does not make sense to insert <ins> and <del> tags.
+ *     If not used, the default list 'iframe|object|math|svg|script|head|style' will be used.
  *
  * @return {string} The combined HTML content with differences wrapped in <ins> and <del> tags.
  */
-declare function diff(before: string, after: string, className?: string, dataPrefix?: string): string;
+declare function diff(before: string, after: string, className?: string | null, dataPrefix?: string | null, atomicTags?: string | null): string;
 export = diff;

--- a/js/htmldiff.js
+++ b/js/htmldiff.js
@@ -65,6 +65,14 @@
     }
 
     /**
+     * Regular expression to check atomic tags.
+     * @see function diff.
+     */
+    var atomicTagsRegExp;
+    // Added head and style (for style tags inside the body)
+    var defaultAtomicTagsRegExp = new RegExp('^<(iframe|object|math|svg|script|head|style)');
+    
+    /**
      * Checks if the current word is the beginning of an atomic tag. An atomic tag is one whose
      * child nodes should not be compared - the entire tag should be treated as one token. This
      * is useful for tags where it does not make sense to insert <ins> and <del> tags.
@@ -75,7 +83,7 @@
      *    null otherwise
      */
     function isStartOfAtomicTag(word){
-        var result = /^<(iframe|object|math|svg|script)/.exec(word);
+        var result = atomicTagsRegExp.exec(word);
         return result && result[1];
     }
 
@@ -897,11 +905,17 @@
      * @param {string} className (Optional) The class attribute to include in <ins> and <del> tags.
      * @param {string} dataPrefix (Optional) The data prefix to use for data attributes. The
      *      operation index data attribute will be named `data-${dataPrefix-}operation-index`.
+     * @param {string} atomicTags (Optional) List of atomic tag names. The list has to be in the 
+     *     form 'tag1|tag2|tag3|...' e. g. 'head|script|style|...'. If not used, the default list 
+     *     'iframe|object|math|svg|script|head|style' will be used.
      *
      * @return {string} The combined HTML content with differences wrapped in <ins> and <del> tags.
      */
-    function diff(before, after, className, dataPrefix){
+    function diff(before, after, className, dataPrefix, atomicTags){
         if (before === after) return before;
+
+        // Enable user provided atomic tag list.
+        atomicTags ? (atomicTagsRegExp = new RegExp('^<(' + atomicTags + ')')) : (atomicTagsRegExp = defaultAtomicTagsRegExp);
 
         before = htmlToTokens(before);
         after = htmlToTokens(after);


### PR DESCRIPTION
Makes atomic tags configurable via additional parameter of diff function. 

Adds 'head' and 'style' to default list of atomic tags.